### PR TITLE
cerberus now hourly for digitaladapt

### DIFF
--- a/digitaladapt/chains.json
+++ b/digitaladapt/chains.json
@@ -6,7 +6,7 @@
       "address": "cerberusvaloper1krkmg6f0sjwalkx3nq39yt0upxgys7alcjytq4",
       "restake": {
         "address": "cerberus1h666jcyjycu90w3j6q6cpswsmzh9f73txjnkf9",
-        "run_time": "every 10 minutes",
+        "run_time": "every 1 hour",
         "minimum_reward": 1000000
       }
     },


### PR DESCRIPTION
because 50,000 extra transactions annually seems a bit much for increasing the APY by 0.01%.