### PR TITLE
Restake support for new EVMOS Validator StakeLikeMo.

### DIFF
--- a/stakelikemo/chains.json
+++ b/stakelikemo/chains.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../chains.schema.json",
+  "name": "StakeLikeMo",
+  "chains": [
+    {
+      "name": "evmos",
+      "address": "evmosvaloper1vkrhllc9ufpymtgpxhaqfp8qcxw7cnhuk3c6l6",
+      "restake": {
+        "address": "evmos1c3e699nxhdl4qhe5egtz4pf4skgsyusm2afwdt",
+        "run_time": "every 1 hour",
+        "minimum_reward": 100000000000000000
+      }
+    }
+  ]
+}

--- a/stakelikemo/profile.json
+++ b/stakelikemo/profile.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../profile.schema.json",
+  "name": "StakeLikeMo",
+  "identity": "7061E0A882E97F57"
+}


### PR DESCRIPTION
FYI: I've put this in new folder because it's a collaboration between CryptoLikeMo and DigtialAdapt, and has separate branding specific to that.