### PR TITLE
Fix operator address

### DIFF
--- a/tessellated-geometry/chains.json
+++ b/tessellated-geometry/chains.json
@@ -13,7 +13,7 @@
 		},
 		{
 			"name": "evmos",
-			"address": "evmosvaloper1umk407eed7af6anvut6llg2zevnf0dn0feqqny",
+			"address": "evmosvaloper1mfu6uer0zatrqaz6435m2zk40ls25tt38r4t8t",
 			"restake": {
 				"address": "evmos19lxrasudzvm9dmhredcrfpme46rkutqtaqaqsy",
 				"run_time": "9:00",


### PR DESCRIPTION
This accidentally pointed to Ecostake's address, not Tessellated Geometry.

I double checked the other 3 addresses.