### PR TITLE
change min reward for fina cash validator

### DIFF
--- a/FinaCash/chains.json
+++ b/FinaCash/chains.json
@@ -8,7 +8,7 @@
       "restake": {
         "address": "secret19q758ccrc9hpmyqkhanwtzjly9vy2vr9pyezm4",
         "run_time": "21:00",
-        "minimum_reward": 1000000
+        "minimum_reward": 100000
       }
     }
   ]


### PR DESCRIPTION
Lower the minimum reward so we can restake for our users faster