### PR TITLE
Update chains.json

### DIFF
--- a/ottersync/chains.json
+++ b/ottersync/chains.json
@@ -13,7 +13,7 @@
     },
     {
       "name": "umee",
-      "address": "umeevaloper18l70l7sy36g5zh56tuwpghuxj2gwv7gytlkdc0",
+      "address": "umeevaloper18h0g960uszf898fyfqmdz8tfkv32ke76nfag02",
       "restake": {
         "address": "umee1p0mr7h222e7ljkcmuje8gz0ayv43u50qn8c2nk",
         "run_time": "every 1 hour",


### PR DESCRIPTION
Replacing our old validator with a new one. Old one is now marked REDELEGATE for 30 days.