### PR TITLE
Remove GalaxyStaking.space acre validator

### DIFF
--- a/GalaxyStaking.space/chains.json
+++ b/GalaxyStaking.space/chains.json
@@ -30,15 +30,6 @@
       }
     },
     {
-      "name": "acrechain",
-      "address": "acrevaloper17j2z96kwktql80ql9qa3ljg9zj0jvue5x2njyk",
-      "restake": {
-        "address": "acre17vtz20nrmz0zr02cpqn9r0dueyqhyx0am6xt68",
-        "run_time": "20:30",
-        "minimum_reward": 1000000000000000000
-      }
-    },
-    {
       "name": "evmos",
       "address": "evmosvaloper1d6c097pmd6avh0x3spfwc0cagc690e2mmkpx4h",
       "restake": {


### PR DESCRIPTION
this PR removes the acre validator of GalaxyStaking.space as it stops operations on 20/08/2023