### PR TITLE
Use list instead of string for run_time

### DIFF
--- a/kjnodes/chains.json
+++ b/kjnodes/chains.json
@@ -196,7 +196,7 @@
       "address": "celestiavaloper17p8y0sm76zhrtjny98tknevafvlq9860ehykz3",
       "restake": {
         "address": "celestia1murx57yjv5r5gvspcxxd8d3w0mmy52xtx7zgjj",
-        "run_time": "every 5 minutes",
+        "run_time": ["every 5 minutes"],
         "minimum_reward": 1000000
       }
     }


### PR DESCRIPTION
In our build scripts we parse it as a list, so we would prefer to keep this data type