### PR TITLE
interop: re-add osmosis & quicksilver chains

### DIFF
--- a/interop/chains.json
+++ b/interop/chains.json
@@ -2,6 +2,24 @@
   "name": "Interop",
   "chains": [
     {
+      "name": "osmosis",
+      "address": "osmovaloper146mj09yzu3mvz7pmy4dvs4z9wr2mst7rq8p8gy",
+      "restake": {
+        "address": "osmo1kvy6f35jt2hegljz7vj8u6sehadfpfr37aandf",
+        "run_time": "10:00",
+        "minimum_reward": 500000
+      }
+    },
+    {
+      "name": "quicksilver",
+      "address": "quickvaloper1wr38atcruxqh4u49q998n065g2mhsrskl4et7n",
+      "restake": {
+        "address": "quick1kvy6f35jt2hegljz7vj8u6sehadfpfr3az73zf",
+        "run_time": "10:00",
+        "minimum_reward": 500000
+      }
+    },
+    {
       "name": "lava",
       "address": "lava@valoper1cqks7sdvw968jjd90knphf9aqscfx0uq6fk0em",
       "restake": {


### PR DESCRIPTION
This chain were already added via commit 2d17a0d91b7962d156ccb55910de568c5fbd1929
But looks like it has been override by creating a folder with same name but different case in commit 6b329bfa6fcf89e3229b4c5032a7a7682f767372