### PR TITLE
WhisperNode - remove deprecated mainnet networks

### DIFF
--- a/whispernode/chains.json
+++ b/whispernode/chains.json
@@ -12,24 +12,6 @@
       }
     },
     {
-      "name": "archway",
-      "address": "archwayvaloper1xjyw0swav97upg2f5trvuxrmzympm0gu092alx",
-      "restake": {
-        "address": "archway1e44rluarkdw56dy2turnwjtvtg4wqvs08qfqaj",
-        "run_time": "every 12 hours",
-        "minimum_reward": 100000000000000
-      }
-    },
-    {
-      "name": "assetmantle",
-      "address": "mantlevaloper170ef5gajk5q8t90cv6qcmfv4ljwzuqtsklsgn6",
-      "restake": {
-        "address": "mantle1e44rluarkdw56dy2turnwjtvtg4wqvs0v0wpg0",
-        "run_time": "every 12 hours",
-        "minimum_reward": 100000
-      }
-    },
-    {
       "name": "axelar",
       "address": "axelarvaloper1j5vxzfx74xlml73e2mz9nn2ultz9jhzxjsakxw",
       "restake": {
@@ -45,15 +27,6 @@
         "address": "cheqd1e44rluarkdw56dy2turnwjtvtg4wqvs0ufeyu5",
         "run_time": "16:00",
         "minimum_reward": 10000000
-      }
-    },
-    {
-      "name": "comdex",
-      "address": "comdexvaloper19qz6sgw7llrft2x05lp4swy569e5sla6gl3cuu",
-      "restake": {
-        "address": "comdex1e44rluarkdw56dy2turnwjtvtg4wqvs04yhxwj",
-        "run_time": "18:00",
-        "minimum_reward": 100000
       }
     },
     {
@@ -79,24 +52,6 @@
       }
     },
     {
-      "name": "empowerchain",
-      "address": "empowervaloper1u2urd0ta23k0acwhpwka4370qv0wt92knwdxnw",
-      "restake": {
-        "address": "empower1e44rluarkdw56dy2turnwjtvtg4wqvs0w830dm",
-        "run_time": "every 12 hours",
-        "minimum_reward": 100000
-      }
-    },
-    {
-      "name": "gitopia",
-      "address": "gitopiavaloper1p804l07cxwmscgs9xy46kfua3sv06jfj7q7dxj",
-      "restake": {
-        "address": "gitopia1e44rluarkdw56dy2turnwjtvtg4wqvs0vnjncx",
-        "run_time": "every 12 hours",
-        "minimum_reward": 100000
-      }
-    },
-    {
       "name": "injective",
       "address": "injvaloper1cutynk8xve9lqmwt4nn575x95v9849zj6p9564",
       "restake": {
@@ -110,24 +65,6 @@
       "address": "jklvaloper1upt02z2a64m00rh087q8r2esy7mg9yeq29j8gz",
       "restake": {
         "address": "jkl1e44rluarkdw56dy2turnwjtvtg4wqvs0t4m4w6",
-        "run_time": "every 12 hours",
-        "minimum_reward": 100000
-      }
-    },
-    {
-      "name": "juno",
-      "address": "junovaloper193xl2tqh2tjkld2zv49ku5s44ee4qmgr65jcep",
-      "restake": {
-        "address": "juno1e44rluarkdw56dy2turnwjtvtg4wqvs0yeklse",
-        "run_time": "every 12 hours",
-        "minimum_reward": 100000
-      }
-    },
-    {
-      "name": "kujira",
-      "address": "kujiravaloper1med39q63mwzxgqdzus70lp98krdrfmhhm4v8al",
-      "restake": {
-        "address": "kujira1e44rluarkdw56dy2turnwjtvtg4wqvs0rrhu60",
         "run_time": "every 12 hours",
         "minimum_reward": 100000
       }
@@ -167,33 +104,6 @@
       }
     },
     {
-      "name": "passage",
-      "address": "pasgvaloper1c42pgxrg652f2f26dfgj40a7y5rhkt0wm9hwfj",
-      "restake": {
-        "address": "pasg1e44rluarkdw56dy2turnwjtvtg4wqvs03nv766",
-        "run_time": "every 12 hours",
-        "minimum_reward": 100000
-      }
-    },
-    {
-      "name": "picasso",
-      "address": "picavaloper1c3npqc23h0rw0s2s5la0umel4w0uff94uht7ww",
-      "restake": {
-        "address": "pica1e44rluarkdw56dy2turnwjtvtg4wqvs0fhkpnz",
-        "run_time": "every 12 hours",
-        "minimum_reward": 100000
-      }
-    },
-    {
-      "name": "quasar",
-      "address": "quasarvaloper1qpr2ezeut3xmarqsxddyld0sdlkrppgpq6alhj",
-      "restake": {
-        "address": "quasar1e44rluarkdw56dy2turnwjtvtg4wqvs0ug0e6q",
-        "run_time": "every 12 hours",
-        "minimum_reward": 100000
-      }
-    },
-    {
       "name": "secretnetwork",
       "address": "secretvaloper16k26akna7h295rfjx3278s7xusnt736vy437y8",
       "restake": {
@@ -216,33 +126,6 @@
       "address": "seivaloper1es38d8hn854vdcg8ql6fr3cycmahj6qypmpefu",
       "restake": {
         "address": "sei1e44rluarkdw56dy2turnwjtvtg4wqvs0l8yj3y",
-        "run_time": "every 12 hours",
-        "minimum_reward": 100000
-      }
-    },
-    {
-      "name": "sentinel",
-      "address": "sentvaloper1tjgec0ssfrlldmut69xsp8vzljugg0g306aae2",
-      "restake": {
-        "address": "sent1e44rluarkdw56dy2turnwjtvtg4wqvs0fsran2",
-        "run_time": "17:00",
-        "minimum_reward": 1000000
-      }
-    },
-    {
-      "name": "stargaze",
-      "address": "starsvaloper17z2ynnlm8evtjpzvsw3239w75474rc7a4du4l3",
-      "restake": {
-        "address": "stars1e44rluarkdw56dy2turnwjtvtg4wqvs0xhzeu5",
-        "run_time": "every 12 hours",
-        "minimum_reward": 100000
-      }
-    },
-    {
-      "name": "stratos",
-      "address": "stvaloper1qlp8jhykjxglutn4q493p7ltxkt7kw33uhxd44",
-      "restake": {
-        "address": "st1q28av45sstxw932cj5dgnanua3seaeua2gmcta",
         "run_time": "every 12 hours",
         "minimum_reward": 100000
       }


### PR DESCRIPTION
Updating our validator profile to remove chains that we no longer support on mainnet.