### PR TITLE
chorusone: Remove offboarded networks

### DIFF
--- a/chorusone/chains.json
+++ b/chorusone/chains.json
@@ -3,18 +3,6 @@
   "name": "Chorus One",
   "chains": [
     {
-      "name": "agoric",
-      "address": "agoricvaloper15urq2dtp9qce4fyc85m6upwm9xul3049770a06",
-      "restake": {
-        "address": "agoric136ppqhwcg575ynv75sjxyf4g4qjey8ajwd0phy",
-        "run_time": [
-          "11:31",
-          "23:31"
-        ],
-        "minimum_reward": 1000000
-      }
-    },
-    {
       "name": "akash",
       "address": "akashvaloper16pj5gljqnqs0ajxakccfjhu05yczp987ptmjx9",
       "restake": {
@@ -135,42 +123,6 @@
       }
     },
     {
-      "name": "lava",
-      "address": "lava@valoper16pj5gljqnqs0ajxakccfjhu05yczp9872r5360",
-      "restake": {
-        "address": "lava@1qa6ssu05nslkj2smaqcjx2x9fzanfkpfey75np",
-        "run_time": [
-          "05:22",
-          "17:22"
-        ],
-        "minimum_reward": 1000000
-      }
-    },
-    {
-      "name": "dymension",
-      "address": "dymvaloper1ema6flggqeakw3795cawttxfjspa48l4x0e2mh",
-      "restake": {
-        "address": "dym1z6r5e39dfugvde34ewvak0e9tqe8lftddenc0t",
-        "run_time": [
-          "07:15",
-          "19:15"
-        ],
-        "minimum_reward": 1000000000000000000
-      }
-    },
-    {
-      "name": "neutron",
-      "address": "neutronvaloper15urq2dtp9qce4fyc85m6upwm9xul3049zewslw",
-      "restake": {
-        "address": "neutron1yr2z65ms3anah0nmtzp5cj3k0may2vq8c4tqz4",
-        "run_time": [
-          "05:23",
-          "17:23"
-        ],
-        "minimum_reward": 1000000
-      }
-    },
-    {
       "name": "onomy",
       "address": "onomyvaloper16pj5gljqnqs0ajxakccfjhu05yczp987q5wjzx",
       "restake": {
@@ -195,66 +147,6 @@
       }
     },
     {
-      "name": "passage",
-      "address": "pasgvaloper16pj5gljqnqs0ajxakccfjhu05yczp987kktprk",
-      "restake": {
-        "address": "pasg1nyqg5k7ql4s8n3s5jmh7220yukhv7ae6jxptfw",
-        "run_time": [
-          "03:57",
-          "15:57"
-        ],
-        "minimum_reward": 1000000
-      }
-    },
-    {
-      "name": "persistence",
-      "address": "persistencevaloper15urq2dtp9qce4fyc85m6upwm9xul3049mnc9ys",
-      "restake": {
-        "address": "persistence15pnsz206ttegjf6hkr503gu3hp5l37tu6ac60z",
-        "run_time": [
-          "09:52",
-          "21:52"
-        ],
-        "minimum_reward": 1000000
-      }
-    },
-    {
-      "name": "persistencetestnet2",
-      "address": "persistencevaloper1739can4hqj2pm8cka8mqhp07zulegkylgwjkf8",
-      "restake": {
-        "address": "persistence1vcl8w68gzvvmramsvzpdyy24etv89ukq6zq79c",
-        "run_time": [
-          "02:17",
-          "14:17"
-        ],
-        "minimum_reward": 1000000
-      }
-    },
-    {
-      "name": "quicksilver",
-      "address": "quickvaloper16pj5gljqnqs0ajxakccfjhu05yczp987nmxvcw",
-      "restake": {
-        "address": "quick1uqsuqrydhemlzq7ekv8ch2amw5r5y62wujsrgs",
-        "run_time": [
-          "02:34",
-          "14:34"
-        ],
-        "minimum_reward": 1000000
-      }
-    },
-    {
-      "name": "regen",
-      "address": "regenvaloper15urq2dtp9qce4fyc85m6upwm9xul3049l7gjdc",
-      "restake": {
-        "address": "regen1r3kcerf42l80xk2ncspvvpk60scsq9gur2s53l",
-        "run_time": [
-          "11:01",
-          "23:01"
-        ],
-        "minimum_reward": 1000000
-      }
-    },
-    {
       "name": "sei",
       "address": "seivaloper16pj5gljqnqs0ajxakccfjhu05yczp98743ctgy",
       "restake": {
@@ -262,18 +154,6 @@
         "run_time": [
           "09:19",
           "21:19"
-        ],
-        "minimum_reward": 1000000
-      }
-    },
-    {
-      "name": "sommelier",
-      "address": "sommvaloper15urq2dtp9qce4fyc85m6upwm9xul30499el64g",
-      "restake": {
-        "address": "somm1amd4wvs5n2y5qtgt2s9ngj6cmy5e5yrtmmatdu",
-        "run_time": [
-          "04:22",
-          "16:22"
         ],
         "minimum_reward": 1000000
       }


### PR DESCRIPTION
List of removed networks:
- Agoric
- Lava
- Dymension
- Neutron
- Passage (aka Passage3d)
- Persistence (Testnet)
- Persistence
- Quicksilver
- Regen
- Sommelier