### PR TITLE
Ryddd29: Add new support chain- Medas Digital & Dhealth

### DIFF
--- a/Ryddd29/chains.json
+++ b/Ryddd29/chains.json
@@ -17,7 +17,7 @@
       "restake": {
         "address": "medas1tzlf0j3qfg4g7qdxkrsmuph5pkcm68xfw3wf7k",
         "run_time": "every 1 minutes",
-        "minimum_reward": 100000
+        "minimum_reward": 1000000
       }
     },
     {

--- a/Ryddd29/chains.json
+++ b/Ryddd29/chains.json
@@ -10,6 +10,15 @@
         "run_time": "every 1 hours",
         "minimum_reward": 100000
       }
+    },
+    {
+      "name": "medas",
+      "address": "medasvaloper1npw0kkuh5gmw22nxpumax442fpxuz5uvu3atuq",
+      "restake": {
+        "address": "medas1tzlf0j3qfg4g7qdxkrsmuph5pkcm68xfw3wf7k",
+        "run_time": "every 1 minutes",
+        "minimum_reward": 100000
+      }
     }
   ]
 }

--- a/Ryddd29/chains.json
+++ b/Ryddd29/chains.json
@@ -12,12 +12,21 @@
       }
     },
     {
-      "name": "medas",
+      "name": "medasdigital",
       "address": "medasvaloper1npw0kkuh5gmw22nxpumax442fpxuz5uvu3atuq",
       "restake": {
         "address": "medas1tzlf0j3qfg4g7qdxkrsmuph5pkcm68xfw3wf7k",
         "run_time": "every 1 minutes",
         "minimum_reward": 100000
+      }
+    },
+    {
+      "name": "dhealth",
+      "address": "dhvaloper1yt0t49ykx2yc0ln9ywmnq2mfd69upvx97u4kpl",
+      "restake": {
+        "address": "dh1eslrzyvekh0w6qy2fmk8l3egnsq2faztgrafkq",
+        "run_time": "every 1 hours",
+        "minimum_reward": 1000000
       }
     }
   ]


### PR DESCRIPTION
Add Medas Digital and Dhealth to restake.app auto-compounding list under "Stake With Ryddd".

- **Validator Medas:** `medasvaloper1npw0kkuh5gmw22nxpumax442fpxuz5uvu3atuq`
- **Restake address:** `medas1tzlf0j3qfg4g7qdxkrsmuph5pkcm68xfw3wf7k`
- **Run time:** every 1 minute
- **Minimum reward:** 1000000 (1 MEDAS)

- **Validator Dhealth:** `dhvaloper1yt0t49ykx2yc0ln9ywmnq2mfd69upvx97u4kpl`
- **Restake address:** `dh1eslrzyvekh0w6qy2fmk8l3egnsq2faztgrafkq`
- **Run time:** every 1 hour
- **Minimum reward:** 1000000 (1 DHP)