### PR TITLE
interop: remove lava/passage3d

### DIFF
--- a/interop/chains.json
+++ b/interop/chains.json
@@ -18,30 +18,6 @@
         "run_time": "10:00",
         "minimum_reward": 500000
       }
-    },
-    {
-      "name": "lava",
-      "address": "lava@valoper1cqks7sdvw968jjd90knphf9aqscfx0uq6fk0em",
-      "restake": {
-        "address": "lava@1wnmy46k8u392z90jhpgznqgeauly6dqvp9reg2",
-        "run_time": [
-          "06:17",
-          "18:17"
-        ],
-        "minimum_reward": 1000000
-      }
-    },
-    {
-      "name": "passage",
-      "address": "pasgvaloper1cqks7sdvw968jjd90knphf9aqscfx0uqxuflqz",
-      "restake": {
-        "address": "pasg10jxattc283uslgkzm4rp9jvyesq3vjk8ngdjm8",
-        "run_time": [
-          "11:03",
-          "23:03"
-        ],
-        "minimum_reward": 1000000
-      }
     }
   ]
 }


### PR DESCRIPTION
nodes are inactive:
<img width="1243" height="281" alt="image" src="https://github.com/user-attachments/assets/22af2a58-efc2-4a2e-864b-ca079f174389" />

https://staking-explorer.com/staking/passage


<img width="1398" height="474" alt="image" src="https://github.com/user-attachments/assets/a7997096-5a33-4610-b544-48a19c382fe6" />

https://lava.explorers.guru/validator/lava@valoper1cqks7sdvw968jjd90knphf9aqscfx0uq6fk0em