### PR TITLE
Add POLCRYPTO.PL public node endpoints for Chain4Energy

### DIFF
--- a/POLCRYPTO.PL/services.json
+++ b/POLCRYPTO.PL/services.json
@@ -8,7 +8,7 @@
       "items": [
         { "type": "RPC",  "address": "https://rpc.polcrypto.pl",  "provider": "POLCRYPTO.PL" },
         { "type": "REST", "address": "https://rest.polcrypto.pl", "provider": "POLCRYPTO.PL" },
-        { "type": "gRPC", "address": "grpc.polcrypto.pl:443",     "provider": "POLCRYPTO.PL" }
+        { "type": "gRPC", "address": "https://grpc.polcrypto.pl:443", "provider": "POLCRYPTO.PL" }
       ]
     }
   ]

--- a/POLCRYPTO.PL/services.json
+++ b/POLCRYPTO.PL/services.json
@@ -5,6 +5,7 @@
     {
       "chain": "chain4energy",
       "category": "Public Nodes",
+      "title": "POLCRYPTO.PL public endpoints for Chain4Energy",
       "items": [
         { "type": "RPC",  "address": "https://rpc.polcrypto.pl",  "provider": "POLCRYPTO.PL" },
         { "type": "REST", "address": "https://rest.polcrypto.pl", "provider": "POLCRYPTO.PL" },

--- a/POLCRYPTO.PL/services.json
+++ b/POLCRYPTO.PL/services.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../services.schema.json",
+  "name": "POLCRYPTO.PL",
+  "services": [
+    {
+      "chain": "chain4energy",
+      "category": "Public Nodes",
+      "items": [
+        { "type": "RPC",  "address": "https://rpc.polcrypto.pl",  "provider": "POLCRYPTO.PL" },
+        { "type": "REST", "address": "https://rest.polcrypto.pl", "provider": "POLCRYPTO.PL" },
+        { "type": "gRPC", "address": "grpc.polcrypto.pl:443",     "provider": "POLCRYPTO.PL" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds the public RPC, REST and gRPC endpoints for the POLCRYPTO.PL validator on Chain4Energy.

- RPC:  https://rpc.polcrypto.pl
- REST: https://rest.polcrypto.pl
- gRPC: grpc.polcrypto.pl:443

Category: Public Nodes