### PR TITLE
Modify restake settings and update chain entries

### DIFF
--- a/oneiric-stake/chains.json
+++ b/oneiric-stake/chains.json
@@ -7,7 +7,7 @@
       "address": "terravaloper14qv3eec9chk0d55ldjpffjwdet3wf4tdetqkk2",
       "restake": {
         "address": "terra13cfqm24s5n6lwmsvt0l4xxqpv7zsaqlrvf5nwg",
-        "run_time": "Hourly",
+        "run_time": "every 1 hour",
         "minimum_reward": 1
       }
     },
@@ -16,7 +16,7 @@
       "address": "pasgvaloper14m0n559xdj00qwvp6ck0xesprrq26kgpqsa6c4",
       "restake": {
         "address": "pasg1sxe282urhqqx7pjp0s4jqsefuhp069lh2z3ks5",
-        "run_time": "Hourly",
+        "run_time": "every 1 hour",
         "minimum_reward": 1
       }
     },
@@ -25,7 +25,7 @@
       "address": "sentvaloper14m0n559xdj00qwvp6ck0xesprrq26kgp528uls",
       "restake": {
         "address": "sent1sxe282urhqqx7pjp0s4jqsefuhp069lhjp74ey",
-        "run_time": "Hourly",
+        "run_time": "every 1 hour",
         "minimum_reward": 1
       }
     },
@@ -34,7 +34,7 @@
       "address": "sourcevaloper14m0n559xdj00qwvp6ck0xesprrq26kgpke3xl2",
       "restake": {
         "address": "source1sxe282urhqqx7pjp0s4jqsefuhp069lh0f3jd4",
-        "run_time": "Hourly",
+        "run_time": "every 1 hour",
         "minimum_reward": 1
       }
     },
@@ -43,7 +43,7 @@
       "address": "atonevaloper14m0n559xdj00qwvp6ck0xesprrq26kgpufexgk",
       "restake": {
         "address": "atone1sxe282urhqqx7pjp0s4jqsefuhp069lh865ttn",
-        "run_time": "Hourly",
+        "run_time": "every 1 hour",
         "minimum_reward": 1
       }
     }


### PR DESCRIPTION
Updated restake settings for multiple chains to hourly frequency and minimum reward to 1. Replaced 'nois' with 'atomone' and updated its address.