### PR TITLE
Update chains.json by removing and adding chains

### DIFF
--- a/stakely/chains.json
+++ b/stakely/chains.json
@@ -3,15 +3,6 @@
   "name": "Stakely.io",
   "chains": [
     {
-      "name": "agoric",
-      "address": "agoricvaloper1mxhgvj2c93xahahx9d9fc7rwwtufqza5cn6uhn",
-      "restake": {
-        "address": "agoric1hl0jgxre5z0nkyjj07c5vfdy44yk44attzqnlt",
-        "run_time": "every 8 hour",
-        "minimum_reward": 100000
-      }
-    },
-    {
       "name": "cosmoshub",
       "address": "cosmosvaloper16yupepagywvlk7uhpfchtwa0stu5f8cyhh54f2",
       "restake": {
@@ -21,48 +12,12 @@
       }
     },
     {
-      "name": "cryptoorgchain",
-      "address": "crocncl1tkev46yqrjzrjzrqtty30ex68eja2zcltyq2vj",
-      "restake": {
-        "address": "cro1hl0jgxre5z0nkyjj07c5vfdy44yk44atpy24nv",
-        "run_time": "every 8 hour",
-        "minimum_reward": 1000000
-      }
-    },
-    {
-      "name": "evmos",
-      "address": "evmosvaloper19fxanpnjlggzuur3m3x0puk5ez7j9lrttexwsw",
-      "restake": {
-        "address": "evmos135e4ecavyr73p6238edqlpwfwty3fhjng49qae",
-        "run_time": "every 8 hour",
-        "minimum_reward": 10000000000000000
-      }
-    },
-    {
-      "name": "juno",
-      "address": "junovaloper1hx9yj7qgnp8zhkrqfanvz74mcsg9d8eyskvsxg",
-      "restake": {
-        "address": "juno1hl0jgxre5z0nkyjj07c5vfdy44yk44at0dphgp",
-        "run_time": "every 8 hour",
-        "minimum_reward": 100000
-      }
-    },
-    {
       "name": "osmosis",
       "address": "osmovaloper1z5xyynz9ewuf044uaweswldut34z34z3cwpt7y",
       "restake": {
         "address": "osmo1hl0jgxre5z0nkyjj07c5vfdy44yk44at3y3ue0",
         "run_time": "every 8 hour",
         "minimum_reward": 1000
-      }
-    },
-    {
-      "name": "regen",
-      "address": "regenvaloper1kzhxmgp8z05zrj90nd8h5qx9pm949an5y7nwsz",
-      "restake": {
-        "address": "regen1hl0jgxre5z0nkyjj07c5vfdy44yk44atxafsee",
-        "run_time": "every 8 hour",
-        "minimum_reward": 1000000
       }
     },
     {
@@ -111,24 +66,6 @@
       }
     },
     {
-      "name": "injective",
-      "address": "injvaloper1mwerm24kce7dcl59t6n0caw7c8zxgkrjj9svwj",
-      "restake": {
-        "address": "inj135e4ecavyr73p6238edqlpwfwty3fhjnqar24f",
-        "run_time": "every 8 hour",
-        "minimum_reward": 100000000000000000
-      }
-    },
-    {
-      "name": "quicksilver",
-      "address": "quickvaloper13eq8xt9nu4v4la9hc5aeevksenu3se49qxj5xu",
-      "restake": {
-        "address": "quick1hl0jgxre5z0nkyjj07c5vfdy44yk44atjmj7k0",
-        "run_time": "every 8 hour",
-        "minimum_reward": 100000
-      }
-    },
-    {
       "name": "shentu",
       "address": "shentuvaloper1wt9lh4zqe8qqe7azc943l0cyn2kzwk3p4dm57a",
       "restake": {
@@ -142,33 +79,6 @@
       "address": "omniflixvaloper1u0ch8y4ts6qxaqgw5h05mvtca0zq9rtfdwpytm",
       "restake": {
         "address": "omniflix1hl0jgxre5z0nkyjj07c5vfdy44yk44atypn4cr",
-        "run_time": "every 8 hour",
-        "minimum_reward": 100000
-      }
-    },
-    {
-      "name": "passage",
-      "address": "pasgvaloper133snxpf4sp5zezm3vnxzx0c7078g4acue3aj92",
-      "restake": {
-        "address": "pasg1hl0jgxre5z0nkyjj07c5vfdy44yk44at68mkzz",
-        "run_time": "every 8 hour",
-        "minimum_reward": 100000
-      }
-    },
-    {
-      "name": "quasar",
-      "address": "quasarvaloper1cavnsvlvcs9j9xwdt7w5xm2glllmghksq7x5l0",
-      "restake": {
-        "address": "quasar1hl0jgxre5z0nkyjj07c5vfdy44yk44athuc3zc",
-        "run_time": "every 8 hour",
-        "minimum_reward": 100000
-      }
-    },
-    {
-      "name": "neutron",
-      "address": "neutronvaloper16yupepagywvlk7uhpfchtwa0stu5f8cyvpsme6",
-      "restake": {
-        "address": "neutron1hl0jgxre5z0nkyjj07c5vfdy44yk44ataqtw46",
         "run_time": "every 8 hour",
         "minimum_reward": 100000
       }
@@ -190,6 +100,15 @@
         "run_time": "every 8 hour",
         "minimum_reward": 100000
       }
-    }
+    },
+    {
+      "name": "union",
+      "address": "unionvaloper1r89nqf6h2fmggwgmsyh0gd7n3222we9f39u4ck",
+      "restake": {
+         "address": "union1hl0jgxre5z0nkyjj07c5vfdy44yk44atngrypv",
+         "run_time": "every 8 hour",
+         "minimum_reward": 1000000000000000000
+          }
+     }
   ]
 }


### PR DESCRIPTION
Removed several chains from the chains.json configuration, including agoric, cryptoorgchain, evmos, juno, regen, injective, quicksilver, passage, quasar, and neutron. Added union chain with its respective address and restake details.