### PR TITLE
Add SOLID validator (Terra 2)

### DIFF
--- a/SOLID/chains.json
+++ b/SOLID/chains.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "../chains.schema.json",
+    "name": "SOLID",
+    "chains": [
+        {
+            "name": "terra2",
+            "address": "terravaloper1cqc26lnatzxvu0z5nd4yx8m4ecllkm7jlakwrw",
+            "restake": {
+                "address": "terra1lzxjl07fckndg6eu4vq5xd2ww2vlmrc50qzr5k",
+                "run_time": ["09:00", "21:00"],
+                "minimum_reward": 1000000
+            }
+        }
+    ]
+}

--- a/SOLID/profile.json
+++ b/SOLID/profile.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "../profile.schema.json",
+    "name": "SOLID",
+    "identity": "26027CD58FF750A4",
+    "website": "https://validator.solidcapa.com",
+    "description": {
+        "overview": "SOLID is an independent Terra 2 validator powering the Solid Protocol DeFi ecosystem. Automated operations, 24/7 monitoring, and active governance participation."
+    },
+    "contacts": {
+        "twitter": "https://x.com/SolidProtocol_"
+    }
+}


### PR DESCRIPTION
## Add SOLID Validator

**Chain:** Terra 2 (phoenix-1)
**Validator:** `terravaloper1cqc26lnatzxvu0z5nd4yx8m4ecllkm7jlakwrw`
**REStake bot:** `terra1lzxjl07fckndg6eu4vq5xd2ww2vlmrc50qzr5k`
**Schedule:** Twice daily (09:00 & 21:00 UTC)
**Minimum reward:** 1 LUNA

SOLID is an independent Terra 2 validator running the Solid Protocol DeFi ecosystem. We run automated 24/7 operations with active governance participation.

- Website: https://validator.solidcapa.com
- Protocol: https://solidcapa.com
- Keybase identity: `26027CD58FF750A4`