### PR TITLE
CryptoDungeon: add AtomOne + Osmosis

### DIFF
--- a/CryptoDungeon/chains.json
+++ b/CryptoDungeon/chains.json
@@ -37,6 +37,24 @@
         "run_time": ["09:00", "21:00"],
         "minimum_reward": 100000
       }
+    },
+    {
+      "name": "atomone",
+      "address": "atonevaloper13x4pynlp86prhcmtns742kgsgu7pjtzjuy3vwr",
+      "restake": {
+        "address": "atone1w6su2zgdsvufhwl8pdcuephttz2vjw2909h2zy",
+        "run_time": ["09:00", "21:00"],
+        "minimum_reward": 50000
+      }
+    },
+    {
+      "name": "osmosis",
+      "address": "osmovaloper13x4pynlp86prhcmtns742kgsgu7pjtzjz4a3nk",
+      "restake": {
+        "address": "osmo1w6su2zgdsvufhwl8pdcuephttz2vjw29f7cazw",
+        "run_time": ["09:00", "21:00"],
+        "minimum_reward": 200000
+      }
     }
   ]
 }


### PR DESCRIPTION
Adds two more chains to CryptoDungeon's restake config:

- **atomone** — `atonevaloper13x4pynlp86prhcmtns742kgsgu7pjtzjuy3vwr`
- **osmosis** — `osmovaloper13x4pynlp86prhcmtns742kgsgu7pjtzjz4a3nk`

Both validators are live and producing. Bot address derived from the same data bytes as the existing four chains (`w6su2zgdsvufhwl8pdcuephttz2vjw29...`). Schedule matches the existing `09:00 / 21:00` UTC cadence.

Heads-up on AtomOne: it has a split fee model — staking accrues in `uatone`, transaction fees are paid in `uphoton`. The restake bot's atomone-1 wallet needs `uphoton` balance to broadcast claim+delegate, separate from any `uatone` it holds. Already prepared on our side.