### PR TITLE
Add Teshy (Realio / RIO)

### DIFF
--- a/Teshy/chains.json
+++ b/Teshy/chains.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../chains.schema.json",
+  "name": "Teshy 103k Bonded RIO",
+  "chains": [
+    {
+      "name": "realio",
+      "address": "realiovaloper18a32el4maw3pqr8xh3yrl9ja4lejs265a5nxtm",
+      "restake": {
+        "address": "realio10eq6w0a7fpety33uag2f55e9tewxazt4v28aem",
+        "run_time": "every 1 hour",
+        "minimum_reward": 1000000000000000000
+      }
+    }
+  ]
+}

--- a/Teshy/profile.json
+++ b/Teshy/profile.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../profile.schema.json",
+  "name": "Teshy 103k Bonded RIO",
+  "identity": "5F604772316FCBE8",
+  "website": "https://teshy.com"
+}


### PR DESCRIPTION
Adds the **Teshy** operator entry for the **Realio Network** chain (`realio`), RIO validator.

- `Teshy/profile.json` — name, Keybase identity, website
- `Teshy/chains.json` — RIO validator `realiovaloper18a32el4maw3pqr8xh3yrl9ja4lejs265a5nxtm`, REStake enabled (self-hosted bot, runs hourly, 1 RIO minimum reward)

Only the RIO validator is listed; the operator's RST/DSTRX validators are intentionally excluded (their rewards are paid in `ario` but they bond different denoms, so in-place auto-compound is not possible).