### PR TITLE
   Add JJozzieTech (Kava)

### DIFF
--- a/JJozzieTech/chains.json
+++ b/JJozzieTech/chains.json
@@ -1,0 +1,10 @@
+{
+     "$schema": "../chains.schema.json",
+     "name": "JJozzieTech",
+     "chains": [
+       {
+         "name": "kava",
+         "address": "kavavaloper1hymhtrelxqnf7p6ua06eh69u4kc36hq2sf9vtu"
+       }
+     ]
+   }

--- a/JJozzieTech/profile.json
+++ b/JJozzieTech/profile.json
@@ -1,0 +1,5 @@
+{
+     "$schema": "../profile.schema.json",
+     "name": "JJozzieTech",
+     "identity": "C0BB391968FE28AE"
+   }


### PR DESCRIPTION
Adds JJozzieTech operator profile and Kava chain entry.

   Validator: kavavaloper1hymhtrelxqnf7p6ua06eh69u4kc36hq2sf9vtu
   Chain: kava_2222-10
   Keybase: keybase.io/jjozzietech (identity C0BB391968FE28AE)
   Website: https://jjozzietech.com.au/validators/validators-kava/

   Basic directory listing only. No autocompound/restake block at this time.