### PR TITLE
Add JJozzieTech akash chain

### DIFF
--- a/JJozzieTech/chains.json
+++ b/JJozzieTech/chains.json
@@ -5,6 +5,10 @@
        {
          "name": "kava",
          "address": "kavavaloper1hymhtrelxqnf7p6ua06eh69u4kc36hq2sf9vtu"
+       },
+       {
+         "name": "akash",
+         "address": "akashvaloper1a5yj9fnua0tsmpxlage8c4uf2n3kq79jqcylm2"
        }
      ]
    }


### PR DESCRIPTION
Adds akash chain entry to the existing JJozzieTech profile.

- Operator address: akashvaloper1a5yj9fnua0tsmpxlage8c4uf2n3kq79jqcylm2
- Chain: akashnet-2
- Same operator identity (C0BB391968FE28AE) as the existing kava entry
- No restake block for now; may enrol in a later PR

Validator is bonded and signing. Verifiable on Mintscan:
https://www.mintscan.io/akash/validators/akashvaloper1a5yj9fnua0tsmpxlage8c4uf2n3kq79jqcylm2