### PR TITLE
The Hive + House of the Holy: add REStake on dungeon

### DIFF
--- a/HouseOfTheHoly/chains.json
+++ b/HouseOfTheHoly/chains.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../chains.schema.json",
+  "name": "House of the Holy",
+  "chains": [
+    {
+      "name": "dungeon",
+      "address": "dungeonvaloper19qp6fk7lj4y36djnwkvpv4j7pv8x3epcpppugd",
+      "restake": {
+        "address": "dungeon1yg5wsmyzxfdk9cgk5q3rgqa7maa38e4dxknnhc",
+        "run_time": "21:00",
+        "minimum_reward": 100000
+      }
+    }
+  ]
+}

--- a/HouseOfTheHoly/profile.json
+++ b/HouseOfTheHoly/profile.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../profile.schema.json",
+  "name": "House of the Holy",
+  "identity": "8EACDF470915D87F"
+}

--- a/TheHive/chains.json
+++ b/TheHive/chains.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../chains.schema.json",
+  "name": "The Hive",
+  "chains": [
+    {
+      "name": "dungeon",
+      "address": "dungeonvaloper1pkr96cu09pzug2m2w2h97u5snpq3spscvfjwpz",
+      "restake": {
+        "address": "dungeon1yg5wsmyzxfdk9cgk5q3rgqa7maa38e4dxknnhc",
+        "run_time": "21:00",
+        "minimum_reward": 100000
+      }
+    }
+  ]
+}

--- a/TheHive/profile.json
+++ b/TheHive/profile.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "../profile.schema.json",
+  "name": "The Hive",
+  "identity": "4068C4901C215BA5"
+}


### PR DESCRIPTION
Adds REStake for two operator-run validators on dungeon-1 (chain `dungeon`), both bonded and in the active set.

| validator | valoper |
|---|---|
| The Hive | `dungeonvaloper1pkr96cu09pzug2m2w2h97u5snpq3spscvfjwpz` |
| House of the Holy | `dungeonvaloper19qp6fk7lj4y36djnwkvpv4j7pv8x3epcpppugd` |

Both autocompound from the same bot as our existing CryptoDungeon entry, `dungeon1yg5wsmyzxfdk9cgk5q3rgqa7maa38e4dxknnhc`. That bot runs nightly on our own infrastructure and settled 6 delegators on its most recent run; both validators are already in its operator config and a dry run passes with all three loaded.

`run_time` is `21:00` — the single scheduled run the bot actually performs.

Identities are the Keybase hashes published in each validator's on-chain description (`4068C4901C215BA5`, `8EACDF470915D87F`). Both files validate against `profile.schema.json` / `chains.schema.json`.