### PR TITLE
CryptoDungeon: correct REStake bot addresses, drop chains we no longer validate

### DIFF
--- a/CryptoDungeon/chains.json
+++ b/CryptoDungeon/chains.json
@@ -33,8 +33,8 @@
       "name": "dungeon",
       "address": "dungeonvaloper1aj5jlmvqp8dd26rsec6624szthlazdn25leye3",
       "restake": {
-        "address": "dungeon1w6su2zgdsvufhwl8pdcuephttz2vjw290k5t78",
-        "run_time": ["09:00", "21:00"],
+        "address": "dungeon1yg5wsmyzxfdk9cgk5q3rgqa7maa38e4dxknnhc",
+        "run_time": "21:00",
         "minimum_reward": 100000
       }
     },

--- a/CryptoDungeon/chains.json
+++ b/CryptoDungeon/chains.json
@@ -22,7 +22,12 @@
     },
     {
       "name": "atomone",
-      "address": "atonevaloper13x4pynlp86prhcmtns742kgsgu7pjtzjuy3vwr"
+      "address": "atonevaloper13x4pynlp86prhcmtns742kgsgu7pjtzjuy3vwr",
+      "restake": {
+        "address": "atone1yg5wsmyzxfdk9cgk5q3rgqa7maa38e4dx9sjtm",
+        "run_time": "21:00",
+        "minimum_reward": 50000
+      }
     }
   ]
 }

--- a/CryptoDungeon/chains.json
+++ b/CryptoDungeon/chains.json
@@ -6,26 +6,8 @@
       "name": "cosmoshub",
       "address": "cosmosvaloper13x4pynlp86prhcmtns742kgsgu7pjtzj4djh7s",
       "restake": {
-        "address": "cosmos1w6su2zgdsvufhwl8pdcuephttz2vjw29p9td5u",
-        "run_time": ["09:00", "21:00"],
-        "minimum_reward": 50000
-      }
-    },
-    {
-      "name": "stargaze",
-      "address": "starsvaloper13x4pynlp86prhcmtns742kgsgu7pjtzj0m9tz2",
-      "restake": {
-        "address": "stars1w6su2zgdsvufhwl8pdcuephttz2vjw294eusld",
-        "run_time": ["09:00", "21:00"],
-        "minimum_reward": 5000000
-      }
-    },
-    {
-      "name": "juno",
-      "address": "junovaloper13x4pynlp86prhcmtns742kgsgu7pjtzjeknkwx",
-      "restake": {
-        "address": "juno1w6su2zgdsvufhwl8pdcuephttz2vjw29hhgknq",
-        "run_time": ["09:00", "21:00"],
+        "address": "cosmos1yg5wsmyzxfdk9cgk5q3rgqa7maa38e4dg9v4ar",
+        "run_time": "21:00",
         "minimum_reward": 50000
       }
     },
@@ -40,21 +22,7 @@
     },
     {
       "name": "atomone",
-      "address": "atonevaloper13x4pynlp86prhcmtns742kgsgu7pjtzjuy3vwr",
-      "restake": {
-        "address": "atone1w6su2zgdsvufhwl8pdcuephttz2vjw2909h2zy",
-        "run_time": ["09:00", "21:00"],
-        "minimum_reward": 50000
-      }
-    },
-    {
-      "name": "osmosis",
-      "address": "osmovaloper13x4pynlp86prhcmtns742kgsgu7pjtzjz4a3nk",
-      "restake": {
-        "address": "osmo1w6su2zgdsvufhwl8pdcuephttz2vjw29f7cazw",
-        "run_time": ["09:00", "21:00"],
-        "minimum_reward": 200000
-      }
+      "address": "atonevaloper13x4pynlp86prhcmtns742kgsgu7pjtzjuy3vwr"
     }
   ]
 }


### PR DESCRIPTION
Two things, both about our entry telling the truth about what our operator actually does.

**1. The advertised REStake bot addresses are not ones we hold.**

Our operator signs as `…yg5w…`; the entry advertised `…w6su…`, which derives from a different mnemonic entirely (not an HD-index variant) and no process of ours holds. Corrected on all three remaining chains:

| chain | grants on the advertised address | its lifetime txs |
|---|---|---|
| cosmoshub | 31 | 2 |
| dungeon | 24 | — |
| atomone | 7 | — |

On Cosmos Hub that means 31 delegators granted to an address that has broadcast two transactions ever. The bot that does run settled 6 delegators on dungeon on its most recent run, and now runs all three chains.

Existing on-chain grants are unaffected — a registry entry only tells new delegators where to point, so this cannot revoke or redirect an authorization that already exists.

**2. Dropped chains we no longer validate.**

`stargaze`, `juno` and `osmosis` removed — juno and osmosis are unbonded on chain, osmosis also jailed.

`run_time` is now the single `21:00` run the bot actually performs, rather than advertising an unbacked `09:00`.